### PR TITLE
[ENHANCEMENT]  use set() to ensure constant lookup time

### DIFF
--- a/snippets/difference.md
+++ b/snippets/difference.md
@@ -2,11 +2,12 @@
 
 Returns the difference between two iterables.
 
-Use list comprehension to only keep values not contained in `b`
+Use list comprehension to only keep values not contained in `b`. Use set to test `in` in `O(1)` time.
 
 ```python
 def difference(a, b):
-    return [item for item in a if item not in b]
+    _b = set(b)
+    return [item for item in a if item not in _b]
 ```
 ``` python
 difference([1, 2, 3], [1, 2, 4]) # [3]

--- a/snippets/difference.md
+++ b/snippets/difference.md
@@ -2,7 +2,7 @@
 
 Returns the difference between two iterables.
 
-Use list comprehension to only keep values not contained in `b`. Use set to test `in` in `O(1)` time.
+Use list comprehension to only keep values not contained in `b`.
 
 ```python
 def difference(a, b):


### PR DESCRIPTION
## Description
Testing repeatedly `in` with `lists` may lead to overhead with large lists. Complexity down from `O(len(a) * len(b))` to `O(len(a))`.

Example:

```python
import random
import timeit

random.seed(0)

def setdifference(a, b):
    _b = set(b)
    return [x for x in a if x not in _b]

def difference(a, b):
    return [x for x in a if x not in b]

a = [random.randint(0, 10000) for _ in range(1000)]
b = [random.randint(0, 10000) for _ in range(1000)]

print(timeit.timeit(lambda: difference(a, b), number=100))
print(timeit.timeit(lambda: setdifference(a, b), number=100))
print(difference(a, b) == setdifference(a, b))
```
```
0.9770162519998848
0.006592955091036856
True
```
## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. <!-- Check this only if you have updated tag_database and ran lint.py and readme.py in the scripts folder -->
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
